### PR TITLE
Deprecate

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,6 +31,7 @@ Imports:
     gistr,
     httr,
     knitr,
+    lifecycle,
     magrittr,
     readr,
     RJDBC,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,6 +39,7 @@ Imports:
     sendmailR,
     shiny,
     utils,
+    withr,
     yaml
 RoxygenNote: 6.1.1
 URL: http://github.com/Rapporteket/rapbase

--- a/R/GetShinyUserGroups.R
+++ b/R/GetShinyUserGroups.R
@@ -17,5 +17,6 @@
 
 
 getShinyUserGroups <- function(shinySession, testCase = FALSE) {
+  lifecycle::deprecate_warn("1.10.0", "rapbase::GetShinyUserGroups()", "rapbase::getUserGroups()")
   shinySessionInfo(shinySession, entity = "groups", testCase)
 }

--- a/R/GetShinyUserName.R
+++ b/R/GetShinyUserName.R
@@ -17,5 +17,7 @@
 
 
 getShinyUserName <- function(shinySession, testCase = FALSE) {
+  lifecycle::deprecate_warn("1.10.0", "rapbase::GetShinyUserName()",
+                 "rapbase::getUserName()")
   shinySessionInfo(shinySession, entity = "user", testCase)
 }

--- a/R/GetShinyUserReshId.R
+++ b/R/GetShinyUserReshId.R
@@ -17,5 +17,7 @@
 
 
 getShinyUserReshId <- function(shinySession, testCase = FALSE) {
+  lifecycle::deprecate_warn("1.10.0", "rapbase::GetShinyUserReshId()",
+                 "rapbase::getUserReshId()")
   shinySessionInfo(shinySession, entity = "resh_id", testCase)
 }

--- a/R/GetShinyUserRole.R
+++ b/R/GetShinyUserRole.R
@@ -17,5 +17,7 @@
 
 
 getShinyUserRole <- function(shinySession, testCase = FALSE) {
+  lifecycle::deprecate_warn("1.10.0", "rapbase::GetShinyUserRole()",
+                 "rapbase::getUserRole()")
   shinySessionInfo(shinySession, entity = "role", testCase)
 }

--- a/R/ShinySessionInfo.R
+++ b/R/ShinySessionInfo.R
@@ -18,6 +18,8 @@
 #' @export
 
 shinySessionInfo <- function(shinySession, entity, testCase = FALSE) {
+  lifecycle::deprecate_warn("1.10.0", "rapbase::shinySessionInfo()",
+                            "rapbase::userInfo()")
   
   if (is.null(shinySession)) {
     stop("Session information is empty!. Cannot do anything")

--- a/tests/testthat/test-shinySessionInfo.R
+++ b/tests/testthat/test-shinySessionInfo.R
@@ -17,6 +17,22 @@ shinySessionWrongClass <- shinySession
 # simulate ShinySession class for above list
 attr(shinySession, "class") <- "ShinySession"
 
+# now deprecated, main function
+test_that("shinySessionInfo() is deprecated", {
+  expect_warning(shinySessionInfo(shinySession = shinySession, entity="user"))
+})
+
+# now deprecated, wrapper functions
+test_that("wrapper funs are deprecated", {
+  expect_warning(getShinyUserName(shinySession), class = "lifecycle_warning_deprecated")
+  expect_warning(getShinyUserGroups(shinySession), class = "lifecycle_warning_deprecated")
+  expect_warning(getShinyUserReshId(shinySession), class = "lifecycle_warning_deprecated")
+  expect_warning(getShinyUserRole(shinySession), class = "lifecycle_warning_deprecated")
+})
+
+# now deprecated, but should still work
+withr::local_options(list(lifecycle_verbosity = "quiet"))
+
 test_that("Default is to assume real data scenario", {
   expect_equal(getShinyUserName(shinySession), "user1")
   expect_equal(getShinyUserGroups(shinySession), "group1,group2")


### PR DESCRIPTION
old (shiny) session info function with wrappers