### PR TITLE
Subject encoding now part of sendmailR

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rapbase
 Type: Package
 Title: Base Functions and Resources for Rapporteket
-Version: 1.23.1
+Version: 1.23.1.9000
 Authors@R: c(
     person(given = "Are",
            family = "Edvardsen",
@@ -24,7 +24,6 @@ LazyData: true
 Depends:
     R (>= 3.5.0)
 Imports:
-    base64enc,
     bookdown,
     DBI,
     digest,

--- a/R/sendEmail.R
+++ b/R/sendEmail.R
@@ -8,8 +8,7 @@
 #' address, SMTP server url and port number
 #' @param to Character vector containing email addresses. May also contain
 #' full names like '\code{Jane Doe <janed@nowhere.com>}'
-#' @param subject Character string providing email subject. The string is
-#' converted within this function to conform to RFC 1342
+#' @param subject Character string providing email subject.
 #' @param text Character string providing the plain email text
 #' @param attFile Character string providing the full file path to an
 #' attachment. Default is NULL in which case no attachment is made
@@ -21,24 +20,12 @@ sendEmail <- function(conf, to, subject, text, attFile = NULL) {
   if (!is.null(attFile)) {
     stopifnot(file.exists(attFile))
   }
-  # nocov start
 
-  # apply RFC 1342 on headers (i.e. subject)
-  charset <- "=?UTF-8?"
-  enc <- "B?"
-  headPost <- "?="
+  # nocov start
 
   from <- conf$network$sender
   # escape spaces (e.g. when full name is added to <email>)
   to <- gsub(" ", "\\ ", to, fixed = TRUE)
-  # Subject is a header field, hence non-ascii to be base64 encoded
-  # Header lines must be 76 chars or less and split by a space
-  # and contain consistent encoded-word(s)
-  subject <- charToRaw(subject)
-  subject <- base64enc::base64encode(subject, linewidth = 63)
-  subject <- paste(paste0(charset, enc, subject, headPost),
-    collapse = " "
-  )
 
   if (is.null(attFile)) {
     body <- list(text)

--- a/man/sendEmail.Rd
+++ b/man/sendEmail.Rd
@@ -13,8 +13,7 @@ address, SMTP server url and port number}
 \item{to}{Character vector containing email addresses. May also contain
 full names like '\code{Jane Doe <janed@nowhere.com>}'}
 
-\item{subject}{Character string providing email subject. The string is
-converted within this function to conform to RFC 1342}
+\item{subject}{Character string providing email subject.}
 
 \item{text}{Character string providing the plain email text}
 


### PR DESCRIPTION
Previous problems with none ASCII characters in subject header field not showing in email clients is now taken care of by [sendmailR](https://cran.r-project.org/web/packages/sendmailR/index.html), see [changes in its version 1.3-1](https://github.com/olafmersmann/sendmailR/pull/4). Hence, _rapbase_ no longer have to deal with this issue and one out of too many lines under Imports can be removed :tada: 