### PR TITLE
Fjernet --column-statistics=0 fra mysqldump

### DIFF
--- a/R/moduleExport.R
+++ b/R/moduleExport.R
@@ -237,8 +237,7 @@ exportDb <- function(registryName, compress = FALSE, session) {
   conf <- rapbase::getConfig()[[registryName]]
   cmd <- paste0(
     "mysqldump ",
-    "--no-tablespaces --single-transaction --add-drop-database ",
-    "--column-statistics=0 "
+    "--no-tablespaces --single-transaction --add-drop-database "
   )
   cmd <- paste0(
     cmd, "-B -u ", conf$user, " -p", conf$pass, " -h ", conf$host,


### PR DESCRIPTION
Mulig --column-statistics=0 ikke fungerer med enkelte versjoner av MySQL?

Closes #140