### PR TITLE
dev-container: disable authorization

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - 8.8.8.8
     restart: "no"
     environment:
-      PASSWORD: password
+      DISABLE_AUTH: "true"
       DB_HOST: db
       DB_USER: root
       DB_PASS: root


### PR DESCRIPTION
Thus, do not have to login when using rstudio dev container