### PR TITLE
Sett variabel lagd av rapOpenDbConnection til NULL når ferdig

### DIFF
--- a/R/log.R
+++ b/R/log.R
@@ -243,6 +243,7 @@ appendLog <- function(event, name) {
     con <- rapOpenDbConnection(config$r$raplog$key)$con
     DBI::dbAppendTable(con, name, event, row.names = NULL)
     rapCloseDbConnection(con)
+    con <- NULL
   } else {
     stop(paste0(
       "Target ", target, " is not supported. ",
@@ -342,6 +343,7 @@ createLogDbTabs <- function() {
     RMariaDB::dbExecute(con, queries[i])
   }
   rapbase::rapCloseDbConnection(con)
+  con <- NULL
 }
 
 
@@ -464,6 +466,7 @@ sanitizeLog <- function() {
     )
     DBI::dbExecute(con, query)
     rapCloseDbConnection(con)
+    con <- NULL
   }
 
   NULL

--- a/tests/testthat/test-auto-report-db.R
+++ b/tests/testthat/test-auto-report-db.R
@@ -96,6 +96,7 @@ createAutoReportTab <- function() {
     RMariaDB::dbExecute(con, queries[i])
   }
   rapbase::rapCloseDbConnection(con)
+  con <- NULL
 }
 
 test_that("a db for auto report defs can be created", {

--- a/tests/testthat/test-dbConnection.R
+++ b/tests/testthat/test-dbConnection.R
@@ -101,6 +101,7 @@ test_that("A mysql db connection and driver can be provided and cleaned", {
   expect_true(RMariaDB::dbIsValid(l$con))
   rapCloseDbConnection(l$con)
   expect_false(RMariaDB::dbIsValid(l$con))
+  l <- NULL
 })
 
 test_that("Deprecated defunct interface provides an error", {
@@ -153,6 +154,7 @@ test_that("Bigints are returned as integers (not bit64::integer64)", {
   query <- "SELECT * FROM testTable;"
   df <- DBI::dbGetQuery(l$con, query)
   rapCloseDbConnection(l$con)
+  l <- NULL
   expect_is(df[["someBigInt"]], "integer")
 })
 
@@ -170,6 +172,7 @@ if (is.null(checkDb(is_test_that = FALSE))) {
   con <- rapbase::rapOpenDbConnection(regName)$con
   RMariaDB::dbExecute(con, "DROP DATABASE rapbase;")
   rapbase::rapCloseDbConnection(con)
+  con <- NULL
 }
 
 # restore initial state

--- a/tests/testthat/test-moduleExport.R
+++ b/tests/testthat/test-moduleExport.R
@@ -151,6 +151,7 @@ if (is.null(checkDb(is_test_that = FALSE))) {
   con <- rapbase::rapOpenDbConnection(regName)$con
   RMariaDB::dbExecute(con, "DROP DATABASE rapbase;")
   rapbase::rapCloseDbConnection(con)
+  con <- NULL
 }
 
 


### PR DESCRIPTION
Så det var gjort flere plasser. Mulig det vil hjelpe på corrupt db feil-melding