### PR TITLE
dbconnection: Sjekk db-miljøvariabler i stedet for R_RAP_INSTANCE

### DIFF
--- a/R/dbConnection.R
+++ b/R/dbConnection.R
@@ -55,7 +55,11 @@ rapCloseDbConnection <- function(con) {
 #' @keywords internal
 #'
 getDbConfig <- function(registryName = "MYSQL_DB_DATA") {
-  if (Sys.getenv("R_RAP_INSTANCE") %in% c("QAC", "PRODUCTIONC")) {
+  if (
+    ("MYSQL_HOST" %in% names(Sys.getenv())) &
+    ("MYSQL_USER" %in% names(Sys.getenv())) &
+    ("MYSQL_PASSWORD" %in% names(Sys.getenv()))
+  ) {
     conf <- data.frame(
       host = Sys.getenv("MYSQL_HOST"),
       user = Sys.getenv("MYSQL_USER"),

--- a/R/dbConnection.R
+++ b/R/dbConnection.R
@@ -56,9 +56,9 @@ rapCloseDbConnection <- function(con) {
 #'
 getDbConfig <- function(registryName = "MYSQL_DB_DATA") {
   if (
-    ("MYSQL_HOST" %in% names(Sys.getenv())) &
-    ("MYSQL_USER" %in% names(Sys.getenv())) &
-    ("MYSQL_PASSWORD" %in% names(Sys.getenv()))
+    ("MYSQL_HOST" %in% names(Sys.getenv())) &&
+      ("MYSQL_USER" %in% names(Sys.getenv())) &&
+      ("MYSQL_PASSWORD" %in% names(Sys.getenv()))
   ) {
     conf <- data.frame(
       host = Sys.getenv("MYSQL_HOST"),

--- a/tests/testthat/test-dbConnection.R
+++ b/tests/testthat/test-dbConnection.R
@@ -186,18 +186,6 @@ test_that("getDbConfig is working when not db", {
 
 withr::with_envvar(
   new = c(
-    "R_RAP_INSTANCE" = "QAC"
-  ),
-  code = {
-    test_that("Returns empty data frame", {
-      expect_equal(getDbConfig()$host,"")
-    })
-  }
-)
-
-withr::with_envvar(
-  new = c(
-    "R_RAP_INSTANCE" = "QAC",
     "MYSQL_HOST" = "qwerty",
     "MYSQL_USER" = "asdfg",
     "MYSQL_PASSWORD" = "zxcvb",


### PR DESCRIPTION
Så lenge MYSQL_*-variabler finnes brukes disse til db-tilkobling