### PR TITLE
Dropp cyclocomp_linter complexity_limit

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,5 +1,4 @@
 linters: linters_with_defaults(
   object_name_linter(c("camelCase", "snake_case")),
-  cyclocomp_linter(complexity_limit = 32),
   line_length_linter(80))
 exclusions: list("data-raw", "tests")

--- a/R/appLog.R
+++ b/R/appLog.R
@@ -17,7 +17,7 @@ loggerSetup <- function(
   formatterJson <- function(level, message, ...) {
     username <- Sys.getenv(usernameEnv, unset = "unknown")
     appid <- Sys.getenv(appidEnv, unset = "unknown")
-    return(jsonlite::toJSON(
+    jsonlite::toJSON(
       list(
         time = format(Sys.time(), "%Y-%m-%d %H:%M:%OS3"),
         level = attr(level, "level"),
@@ -26,7 +26,6 @@ loggerSetup <- function(
         message = message
       ),
       auto_unbox = TRUE
-    )
     )
   }
   logger::log_layout(formatterJson)

--- a/R/misc.R
+++ b/R/misc.R
@@ -63,9 +63,9 @@ getRapPackages <- function() {
 isRapContext <- function() {
   if (Sys.getenv("R_RAP_INSTANCE") %in%
         c("DEV", "TEST", "QA", "QAC", "PRODUCTION", "PRODUCTIONC")) {
-    return(TRUE)
+    TRUE
   } else {
-    return(FALSE)
+    FALSE
   }
 }
 


### PR DESCRIPTION
cyclocomp_linter er ikke lenger en del av default linters, og pakken cyclocomp installeres derfor ikke samtidig som lintr. Hvis vi ikke installerer cyclocomp, vil testen krasje pga manglende pakke. Gjelder fra versjon 3.2.0 av lintr