### PR TITLE
Deaktiver autoreport-knapp under kjøring

### DIFF
--- a/R/autoReport.R
+++ b/R/autoReport.R
@@ -393,6 +393,7 @@ runAutoReport <- function(
   # get sender from common config
   conf <- rapbase::getConfig("rapbaseConfig.yml")
 
+  message("runAutoReport: Starting processing of auto reports")
   for (i in seq_len(dim(reps)[1])) {
     tryCatch(
       {
@@ -466,6 +467,7 @@ runAutoReport <- function(
       }
     )
   }
+  message("runAutoReport: Finished processing of auto reports")
 }
 
 #' Run bulletin auto reports

--- a/R/moduleAutoReport.R
+++ b/R/moduleAutoReport.R
@@ -63,10 +63,10 @@
 #' @param user List of shiny reactive values providing user metadata and
 #'   privileges corresponding to the return value of
 #'   \code{\link{navbarWidgetServer}}.
-#' @param debug Logical defining if debug options should be made available in
-#'   the GUI. Default is FALSE. If TRUE a button will be made available to
-#'   trigger running all auto reports for a given date. This is mainly useful
-#'   for testing purposes.
+#' @param runAutoReportButton Logical defining if runAutoReport button should
+#'   be made available in the GUI. Default is FALSE. If TRUE, a button will be
+#'   made available to trigger running all auto reports for a given date. This
+#'   is mainly useful for testing purposes.
 #'
 #' @return In general, shiny objects. In particular, \code{autoreportOrgServer}
 #' returns a list with names "name" and "value" with corresponding reactive
@@ -240,7 +240,7 @@ autoReportServer <- function(
   eligible = shiny::reactiveVal(TRUE),
   freq = "month",
   user,
-  debug = FALSE
+  runAutoReportButton = FALSE
 ) {
   stopifnot(
     all(unlist(lapply(user, shiny::is.reactive), use.names = FALSE))
@@ -584,21 +584,26 @@ autoReportServer <- function(
     })
 
     # Option to run all auto reports with a given date by clicking a button.
-    # This is only available if debug = TRUE
+    # This is only available if runAutoReportButton = TRUE
     output$runAutoreport <- shiny::renderUI({
-      if (debug) {
+      if (runAutoReportButton) {
         shiny::tagList(
           shiny::hr(),
+          shiny::h3("Kj\u00F8r alle aktuelle autorapporter"),
+          shiny::p(paste0(
+            "Denne funksjonen er kun for testing og utvikling, ",
+            "og vil lage alle rapporter for gitt dato."
+          )),
           shiny::actionButton(
             inputId = shiny::NS(id, "run_autoreport"),
-            label = "Kj\u00F8r autorapporter"
+            label = "Kj\u00F8r autorapporter",
+            icon = shiny::icon("play"),
+            onclick = "this.disabled=true;"
           ),
           shiny::dateInput(
             inputId = shiny::NS(id, "rapportdato"),
             label = "Kj\u00F8r rapporter med dato:",
-            value = Sys.Date(),
-            min = Sys.Date(),
-            max = Sys.Date() + 366
+            value = Sys.Date() + 1
           ),
           shiny::checkboxInput(
             inputId = shiny::NS(id, "dryRun"),
@@ -617,13 +622,18 @@ autoReportServer <- function(
       dryRun <- !(input$dryRun)
       message("Running all auto reports for date ", dato,
         " and registry ", registryName, ", ",
-        ifelse(dryRun, "WITHOUT", "WITH"),
+        ifelse(input$dryRun, "WITH", "WITHOUT"),
         " sending e-mails. This job was triggered by ", user$fullName()
       )
       rapbase::runAutoReport(
         group = registryName,
         dato = dato,
         dryRun = dryRun
+      )
+      message("Finished running all auto reports for date ", dato)
+      shiny::updateActionButton(
+        inputId = "run_autoreport",
+        disabled = FALSE
       )
     })
   })

--- a/man/autoReport.Rd
+++ b/man/autoReport.Rd
@@ -38,7 +38,7 @@ autoReportServer(
   eligible = shiny::reactiveVal(TRUE),
   freq = "month",
   user,
-  debug = FALSE
+  runAutoReportButton = FALSE
 )
 
 autoReportServer2(...)
@@ -96,10 +96,10 @@ report GUI. Must be one of
 privileges corresponding to the return value of
 \code{\link{navbarWidgetServer}}.}
 
-\item{debug}{Logical defining if debug options should be made available in
-the GUI. Default is FALSE. If TRUE a button will be made available to
-trigger running all auto reports for a given date. This is mainly useful
-for testing purposes.}
+\item{runAutoReportButton}{Logical defining if runAutoReport button should
+be made available in the GUI. Default is FALSE. If TRUE, a button will be
+made available to trigger running all auto reports for a given date. This
+is mainly useful for testing purposes.}
 
 \item{...}{Arguments passed to autoReportServer function}
 }


### PR DESCRIPTION
Autoreport-knapp settes inaktiv så lenge utsendingsjobb foregår. Bruker kan da vite når jobb er ferdig.

Byttet i tillegg argumentnavn i autoreportserver fra debug til runAutoReportButton for når runAutoReportButton skal vises. Lagt inn message før og etter loop i autoreport, for å se om loop er kjørt ferdig.