### PR TITLE
Endret tekst under om-knappen

### DIFF
--- a/inst/howWeDealWithPersonalData.Rmd
+++ b/inst/howWeDealWithPersonalData.Rmd
@@ -11,14 +11,16 @@ params:
 knitr::opts_chunk$set(echo = TRUE)
 ```
 
-###### `r params$pkgInfo`
-
 ---
 
 Hei! Her er en kort oppsummering av hva [Rapporteket](https://rapporteket.github.io/rapporteket/articles/kort_introduksjon.html) vet om deg og hvordan denne informasjonen brukes og lagres.
 
-* Før bruk av [Rapporteket](https://rapporteket.github.io/rapporteket/articles/kort_introduksjon.html) må du gjennom en identitets- og adgangskontroll hos [helseregister.no](https://helseregister.no/), [FALK](https://www.kvalitetsregistre.no/artikkel/ny-losning-palogging-testes-ut-i-februar) eller lignende. Etter innlogging mottar Rapporteket et sett av informasjon om deg slik som _navn_, _epostadresse_ og _telefonnummer_ samt informasjon om din tilknytning til et gitt register, eksempelvis din rolle/funksjon samt tilhørighet til grupper og organisasjoner. Slik informasjon er nødvendig for at Rapporteket skal kunne fungere som en god og sikker resultattjeneste.
+* Før bruk av Rapporteket må du gjennom en identitets- og adgangskontroll hos [FALK](https://falk.nhn.no). Etter innlogging mottar Rapporteket et sett av informasjon om deg slik som _navn_, _epostadresse_ og _telefonnummer_ samt informasjon om din tilknytning til et gitt register, eksempelvis din rolle/funksjon samt tilhørighet til grupper og organisasjoner. Slik informasjon er nødvendig for at Rapporteket skal kunne fungere som en god og sikker resultattjeneste.
 
-* Når [Rapporteket](https://rapporteket.github.io/rapporteket/articles/kort_introduksjon.html) lager en figur, tabell eller dokument benyttes informasjonen om deg til å finne fram relevante data og å sette sammen informasjonen slik at fremstillingen blir riktig ut fra hvilke register og organisasjon du tilhører. Kontaktinformasjonen brukes i tilfelle du abonerer på resultater fra [Rapporteket](https://rapporteket.github.io/rapporteket/articles/kort_introduksjon.html).
+* Når Rapporteket lager en figur, tabell eller dokument benyttes informasjonen om deg til å finne fram relevante data og å sette sammen informasjonen slik at fremstillingen blir riktig ut fra hvilke register og organisasjon du tilhører. Kontaktinformasjonen brukes i tilfelle du abonerer på resultater fra Rapporteket.
 
-* Bruk av [Rapporteket](https://rapporteket.github.io/rapporteket/articles/kort_introduksjon.html) registreres slik at aktiviteten kan dokumenteres i ettertid. Dette er viktig med tanke på å kunne ettergå og ta lærdom av feil, avdekke mulige sikkerhetsbrudd og å etablere statistikk over bruk. Registeret innholder typisk oppføringer over _hvem_, _hva_ og _når_ og slettes fortløpende etter 2 år. Alle opplysninger [Rapporteket](https://rapporteket.github.io/rapporteket/articles/kort_introduksjon.html) har om deg er kun for internt bruk og deles aldri med utenforstående.
+* Bruk av Rapporteket registreres slik at aktiviteten kan dokumenteres i ettertid. Dette er viktig med tanke på å kunne ettergå og ta lærdom av feil, avdekke mulige sikkerhetsbrudd og å etablere statistikk over bruk. Registeret innholder typisk oppføringer over _hvem_, _hva_ og _når_ og slettes fortløpende etter 2 år. Alle opplysninger Rapporteket har om deg er kun for internt bruk og deles aldri med utenforstående.
+
+---
+
+Pakkeinformasjon: `r params$pkgInfo`


### PR DESCRIPTION
Fjernet flere lenker til rapporteket-side (smame lenke fem ganger), og fjernet helseregister.no. La i tillegg info om pakke-versjoner nederst.