### PR TITLE
Starte kalenderuke på mandag + på norsk

### DIFF
--- a/R/moduleAutoReport.R
+++ b/R/moduleAutoReport.R
@@ -450,7 +450,9 @@ autoReportServer <- function(
         # set default to following day
         value = Sys.Date() + 1,
         min = Sys.Date() + 1,
-        max = seq.Date(Sys.Date(), length.out = 2, by = "1 years")[2] - 1
+        max = seq.Date(Sys.Date(), length.out = 2, by = "1 years")[2] - 1,
+        weekstart = 1,
+        language = "no"
       )
     })
 
@@ -598,7 +600,9 @@ autoReportServer <- function(
           shiny::dateInput(
             inputId = shiny::NS(id, "rapportdato"),
             label = "Kj\u00F8r rapporter med dato:",
-            value = Sys.Date() + 1
+            value = Sys.Date() + 1,
+            weekstart = 1,
+            language = "no"
           ),
           shiny::checkboxInput(
             inputId = shiny::NS(id, "sendEmails"),

--- a/R/moduleStats.R
+++ b/R/moduleStats.R
@@ -102,7 +102,9 @@ statsServer <- function(id,
         label = shiny::tags$div(
           shiny::HTML(as.character(shiny::icon("calendar")), "Periode:")
         ),
-        start = min(log()$date), end = max(log()$date), separator = "-"
+        start = min(log()$date), end = max(log()$date), separator = "-",
+        weekstart = 1,
+        language = "no"
       )
     })
 
@@ -182,7 +184,9 @@ statsServer2 <- function(id,
         label = shiny::tags$div(
           shiny::HTML(as.character(shiny::icon("calendar")), "Periode:")
         ),
-        start = min(log()$date), end = max(log()$date), separator = "-"
+        start = min(log()$date), end = max(log()$date), separator = "-",
+        weekstart = 1,
+        language = "no"
       )
     })
 


### PR DESCRIPTION
Standardverdi var start på søndag og engelsk språk. Gjelder dato-velger i autoreport-modul og statistikk-modul.

Closes #304