### PR TITLE
Actions: 'R_COMPILE_AND_INSTALL_PACKAGES: never'

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -42,6 +42,7 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
+          use-public-rspm: true
 
       - uses: r-lib/actions/setup-pandoc@v2
 


### PR DESCRIPTION
For å få raskere CI (installasjon av pakker)