### PR TITLE
Fiks av exportApp

### DIFF
--- a/R/exportApp.R
+++ b/R/exportApp.R
@@ -4,7 +4,7 @@
 #' github team name
 #' @param dbName Character string, can be used to
 #' specify name of database if needed. Defaults to "data",
-#' whcih will work for most registries.
+#' which will work for most registries.
 #' @export
 exportApp <- function(teamName = "", dbName = "data") {
   ui <- shiny::navbarPage(

--- a/man/exportApp.Rd
+++ b/man/exportApp.Rd
@@ -12,7 +12,7 @@ github team name}
 
 \item{dbName}{Character string, can be used to
 specify name of database if needed. Defaults to "data",
-whcih will work for most registries.}
+which will work for most registries.}
 }
 \description{
 Shiny app with database export functionality


### PR DESCRIPTION
Ble ødelagt i versjon 3.0.0 (PR #347, ccb2d0093). exportApp brukte de gamle navnene.

Droppet i tillegg å kalle rapbase-funksjoner med rapbase::. Feil ville sannsynligvis blitt oppdaget i linting hvis kall hadde vært gjort direkte tidligere.