### PR TITLE
Bugfiks i sendEmail

### DIFF
--- a/R/sendEmail.R
+++ b/R/sendEmail.R
@@ -41,7 +41,7 @@ sendEmail <- function(conf, to, subject, text, attFile = NULL) {
       is.null(attFile),
       "",
       paste0(" and attachment: ", attFile)
-    ),
+    )
   ))
   sendmailR::sendmail(
     from, to, subject, body,


### PR DESCRIPTION
Ekstra komma i paste-statement, som førte til krasj av epost-utsending