### PR TITLE
Hopp ut av runAutoreport hvis det ikke finnes oppføringer i databasen

### DIFF
--- a/R/autoReport.R
+++ b/R/autoReport.R
@@ -376,7 +376,7 @@ runAutoReport <- function(
 
   if (dim(reps)[1] == 0) {
     message(
-      "runAutoReport: There is no reports to be processed at all. ",
+      "runAutoReport: There are no reports to be processed. ",
       "Thus, after filtering for type (",
       paste(type, collapse = ", "),
       ifelse(

--- a/tests/testthat/test-auto-report-db.R
+++ b/tests/testthat/test-auto-report-db.R
@@ -132,7 +132,7 @@ test_that("Auto reports not sent if after start date", {
   )
 })
 
-test_that("Auto reports not sent because there is no reports at all", {
+test_that("Auto reports not sent because there are no reports to be processed", {
   check_db()
   expect_message(
     runAutoReport(
@@ -145,7 +145,7 @@ test_that("Auto reports not sent because there is no reports at all", {
   )
 })
 
-test_that("Auto reports not sent because there is no reports at all", {
+test_that("Auto reports not sent because there are no reports to be processed", {
   check_db()
   expect_message(
     runAutoReport(


### PR DESCRIPTION
Filtrering krasjet hvis det ikke fantes noen autoreport-oppføringer i databasen for gitt register.