### PR TITLE
Forenkling av docker-compose-fil

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,58 +1,27 @@
-x-environment: &environment
-  MYSQL_HOST: mysql
-  MYSQL_USER: root
-  MYSQL_PASSWORD: root
-  MYSQL_DB_LOG: raplog
-  MYSQL_DB_AUTOREPORT: autoreport
-  FALK_APP_ID: 80
-  FALK_EXTENDED_USER_RIGHTS: "[{\"A\":80,\"R\":\"LC\",\"U\":1},{\"A\":80,\"R\":\"SC\",\"U\":2},{\"A\":81,\"R\":\"LC\",\"U\":2}]"
-  SHINYPROXY_USERNAME: test@tester.no
-
 services:
-  mysql:
+  db:
     image: mysql:8
-    restart: "no"
     environment:
       MYSQL_ROOT_PASSWORD: root
     volumes:
       - ./dev/db/mysql:/docker-entrypoint-initdb.d
 
-  mssql:
-    image: mcr.microsoft.com/mssql/server:2025-latest
-    platform: "linux/amd64"
-    environment:
-      MSSQL_SA_PASSWORD: "Your_password123"
-      ACCEPT_EULA: "Y"
-    volumes:
-      - ./dev/db/mssql/init.sql:/db/init.sql
-      - ./dev/db/mssql/entrypoint.sh:/entrypoint.sh
-    entrypoint: ["/bin/bash", "/entrypoint.sh"]
-
   dev:
     depends_on:
-      - mysql
-      - mssql
+      - db
     image: rapporteket/rstudio:main
     volumes:
       - ~/.ssh:/home/rstudio/.ssh
       - ~/.gitconfig:/home/rstudio/.gitconfig
-      - .:/home/rstudio/rapbase
-      - ../rapregtemplate/.:/home/rstudio/rapregtemplate
+      - ../.:/home/rstudio/repos
     ports:
       - "8787:8787"
-    restart: "no"
     environment:
-      << : *environment
       DISABLE_AUTH: "true"
-      FALK_EXTENDED_USER_RIGHTS: "[{\\\"A\\\":80,\\\"R\\\":\\\"LC\\\",\\\"U\\\":1},{\\\"A\\\":80,\\\"R\\\":\\\"SC\\\",\\\"U\\\":2},{\\\"A\\\":81,\\\"R\\\":\\\"LC\\\",\\\"U\\\":2}]"
 
   adminer:
     depends_on:
-      - mysql
-      - mssql
+      - db
     image: adminer
-    restart: "no"
-    environment:
-      ADMINER_PLUGINS: frames
     ports:
       - 8888:8080


### PR DESCRIPTION
- Droppet mssql
- Droppet miljøvariabler
- endret fra mysql til db (var navnet gitt i rstudio-containeren)
- Mount alle mapper under rapbase-mappa, for å kunne jobbe med alle rapportek.
- Dropp restart: "no" (var uansett default-verdien). Droppet noe adminer-plugins-greier som kanskje ikke var i bruk.