### PR TITLE
Eksport: komprimer som default

### DIFF
--- a/R/moduleExport.R
+++ b/R/moduleExport.R
@@ -223,7 +223,8 @@ exportUCServer <- function(
       } else {
         shiny::checkboxInput(
           shiny::NS(id, "exportCompress"),
-          "Komprimer eksport"
+          "Komprimer eksport",
+          value = TRUE
         )
       }
     })


### PR DESCRIPTION
Bruker opplever at applikasjon kan krasje hvis hen prøver å laste ned databasedump uten komprimering.

Closes #471