### PR TITLE
Bytt fra mysqldump til mariadb-dump

### DIFF
--- a/R/moduleExport.R
+++ b/R/moduleExport.R
@@ -460,7 +460,7 @@ selectListPubkey <- function(pubkey) {
 #' @export
 exportDb <- function(dbName, dropTabs = NULL,
                      tableNames = "", compress = FALSE, session) {
-  stopifnot(Sys.which("mysqldump") != "")
+  stopifnot(Sys.which("mariadb-dump") != "")
   stopifnot(Sys.which("gzip") != "")
 
   conf <- getDbConfig(dbName)

--- a/R/moduleExport.R
+++ b/R/moduleExport.R
@@ -480,11 +480,11 @@ exportDb <- function(dbName, dropTabs = NULL,
 
   cmd_base <- paste0(
     if (Sys.which("mariadb-dump") != "") {
-      "mariadb-dump "
+      "mariadb-dump --skip-ssl "
     } else {
       "mysqldump "
     },
-    "--no-tablespaces --single-transaction --add-drop-database --skip-ssl "
+    "--no-tablespaces --single-transaction --add-drop-database "
   )
 
   cmd <- sprintf(

--- a/R/moduleExport.R
+++ b/R/moduleExport.R
@@ -473,7 +473,7 @@ exportDb <- function(dbName, dropTabs = NULL,
   }
 
   cmd_base <- paste0(
-    "mysqldump ",
+    "mariadb-dump ",
     "--no-tablespaces --single-transaction --add-drop-database --skip-ssl "
   )
 

--- a/R/moduleExport.R
+++ b/R/moduleExport.R
@@ -460,8 +460,14 @@ selectListPubkey <- function(pubkey) {
 #' @export
 exportDb <- function(dbName, dropTabs = NULL,
                      tableNames = "", compress = FALSE, session) {
-  stopifnot(Sys.which("mariadb-dump") != "")
-  stopifnot(Sys.which("gzip") != "")
+  if (!any(Sys.which(c("mariadb-dump", "mysqldump")) != "")) {
+    stop("Neither mariadb-dump nor mysqldump was found in PATH.")
+  }
+  if (compress) {
+    if (Sys.which("gzip") == "") {
+      stop("gzip was not found in PATH.")
+    }
+  }
 
   conf <- getDbConfig(dbName)
   f <- tempfile(pattern = conf$name, fileext = ".sql")
@@ -473,7 +479,11 @@ exportDb <- function(dbName, dropTabs = NULL,
   }
 
   cmd_base <- paste0(
-    "mariadb-dump ",
+    if (Sys.which("mariadb-dump") != "") {
+      "mariadb-dump "
+    } else {
+      "mysqldump "
+    },
     "--no-tablespaces --single-transaction --add-drop-database --skip-ssl "
   )
 


### PR DESCRIPTION
Det dukket opp en advarsel med nyeste versjon av mariadb-bibliotek. `mariadb-dump` ble brukt 'under the hood' i produksjon på NHN og i våre docker-image. På lokal PC og i CI brukes sannsynligvis `mysqldump`, så den må fungere med begge.

Flyttet i tillegg `--skip-ssl` til kun under bruk av `mariadb-dump`, siden den ikke finnes som argument til `mysqldump`.

Closes #480
