### PR TITLE
Legge til flere valg til renderRmd()

### DIFF
--- a/R/renderRmd.R
+++ b/R/renderRmd.R
@@ -42,9 +42,15 @@ renderRmd <- function(sourceFile, outputType = "html", logoFile = NULL,
   # https://github.com/Rapporteket/rapbase/pull/86
   outputType <- as.character(outputType)
 
-  stopifnot(file.exists(sourceFile))
-  stopifnot(outputType %in% c("html", "html_fragment", "pdf"))
-  stopifnot(template %in% c("default", "document"))
+  stopifnot("Can't find 'sourceFile'" = file.exists(sourceFile))
+  stopifnot(
+    '"outputType" must be one of "pdf", "html" or "html_fragment"' =
+      !is.null(outputType) && outputType %in% c("html", "html_fragment", "pdf")
+  )
+  stopifnot(
+    '"template" must be one of "default", "document" or "NULL"' =
+      is.null(template) || template %in% c("default", "document")
+  )
 
   # do work in tempdir and return to origin on exit
   # setwd returns the current directory before the change

--- a/R/renderRmd.R
+++ b/R/renderRmd.R
@@ -34,7 +34,7 @@
 #' @export
 
 renderRmd <- function(sourceFile, outputType = "html", logoFile = NULL,
-                      params = list(), template = "default") {
+                      params = list(), template = "default", quiet = TRUE) {
 
   # When called from do.call (rapbase::runAutoReport()) arguments are provided
   # as class list. To prevent below switch of output formats to fail, make sure
@@ -77,7 +77,7 @@ renderRmd <- function(sourceFile, outputType = "html", logoFile = NULL,
     clean = TRUE,
     params = params,
     envir = new.env(),
-    quiet = TRUE
+    quiet = quiet
   )
 
   if (outputType == "html_fragment") {

--- a/R/renderRmd.R
+++ b/R/renderRmd.R
@@ -20,8 +20,11 @@
 #' header. Default is \code{NULL} in which case no parameters as defined in the
 #' rmarkdown document will be overridden.
 #' @param template Character string defining which template to use for making
-#' pdf documents. Must be one of "default" or "document" where the first is
-#' assumed if this argument is not set.
+#' pdf documents. Must be one of "default", "document", or NULL where the
+#' first is assumed if this argument is not set. NULL means that the default
+#' pandoc template is used.
+#' @param quiet Logical. If TRUE, suppresses output from the rendering process.
+#' TRUE is assumed if this argument is not set.
 #'
 #' @return Character string with path to the rendered file or, if
 #' \code{outputType} is set to "html_fragment", a character string providing an

--- a/R/renderRmd.R
+++ b/R/renderRmd.R
@@ -20,11 +20,11 @@
 #' header. Default is \code{NULL} in which case no parameters as defined in the
 #' rmarkdown document will be overridden.
 #' @param template Character string defining which template to use for making
-#' pdf documents. Must be one of "default", "document", or NULL where the
-#' first is assumed if this argument is not set. NULL means that the default
-#' pandoc template is used.
-#' @param quiet Logical. If TRUE, suppresses output from the rendering process.
-#' TRUE is assumed if this argument is not set.
+#' pdf documents. Must be one of "default", "document", or \code{NULL} where
+#' the first is assumed if this argument is not set. \code{NULL} means that
+#' the default pandoc template is used.
+#' @param quiet Logical. If \code{TRUE}, suppresses output from the
+#' rendering process. \code{TRUE} is assumed if this argument is not set.
 #'
 #' @return Character string with path to the rendered file or, if
 #' \code{outputType} is set to "html_fragment", a character string providing an
@@ -48,7 +48,7 @@ renderRmd <- function(sourceFile, outputType = "html", logoFile = NULL,
       !is.null(outputType) && outputType %in% c("html", "html_fragment", "pdf")
   )
   stopifnot(
-    '"template" must be one of "default", "document" or "NULL"' =
+    '"template" must be one of "default", "document" or NULL' =
       is.null(template) || template %in% c("default", "document")
   )
 

--- a/R/renderRmd.R
+++ b/R/renderRmd.R
@@ -62,12 +62,18 @@ renderRmd <- function(sourceFile, outputType = "html", logoFile = NULL,
     file.copy(logoFile, ".", overwrite = TRUE)
   }
 
+  # Set pandoc arguments for pdf output if a template is specified,
+  # or to use default pandoc template
+  pdoc_args <- if (outputType == "pdf" && !is.null(template)) {
+    paste0("--template=", template, ".latex")
+  }
+
   f <- rmarkdown::render(
     input = basename(sourceFile),
     output_format =
       switch(outputType,
         pdf = bookdown::pdf_document2(
-          pandoc_args = c(paste0("--template=", template, ".latex"))
+          pandoc_args = pdoc_args
         ),
         html = bookdown::html_document2(),
         html_fragment = bookdown::html_fragment2(),

--- a/R/renderRmd.R
+++ b/R/renderRmd.R
@@ -51,6 +51,9 @@ renderRmd <- function(sourceFile, outputType = "html", logoFile = NULL,
     '"template" must be one of "default", "document" or NULL' =
       is.null(template) || template %in% c("default", "document")
   )
+  stopifnot(
+    '"quiet" must be TRUE or FALSE' = length(quiet) == 1 && is.logical(quiet)
+  )
 
   # do work in tempdir and return to origin on exit
   # setwd returns the current directory before the change

--- a/man/renderRmd.Rd
+++ b/man/renderRmd.Rd
@@ -31,12 +31,12 @@ header. Default is \code{NULL} in which case no parameters as defined in the
 rmarkdown document will be overridden.}
 
 \item{template}{Character string defining which template to use for making
-pdf documents. Must be one of "default", "document", or NULL where the
-first is assumed if this argument is not set. NULL means that the default
-pandoc template is used.}
+pdf documents. Must be one of "default", "document", or \code{NULL} where
+the first is assumed if this argument is not set. \code{NULL} means that
+the default pandoc template is used.}
 
-\item{quiet}{Logical. If TRUE, suppresses output from the rendering process.
-TRUE is assumed if this argument is not set.}
+\item{quiet}{Logical. If \code{TRUE}, suppresses output from the
+rendering process. \code{TRUE} is assumed if this argument is not set.}
 }
 \value{
 Character string with path to the rendered file or, if

--- a/man/renderRmd.Rd
+++ b/man/renderRmd.Rd
@@ -9,7 +9,8 @@ renderRmd(
   outputType = "html",
   logoFile = NULL,
   params = list(),
-  template = "default"
+  template = "default",
+  quiet = TRUE
 )
 }
 \arguments{
@@ -30,8 +31,12 @@ header. Default is \code{NULL} in which case no parameters as defined in the
 rmarkdown document will be overridden.}
 
 \item{template}{Character string defining which template to use for making
-pdf documents. Must be one of "default" or "document" where the first is
-assumed if this argument is not set.}
+pdf documents. Must be one of "default", "document", or NULL where the
+first is assumed if this argument is not set. NULL means that the default
+pandoc template is used.}
+
+\item{quiet}{Logical. If TRUE, suppresses output from the rendering process.
+TRUE is assumed if this argument is not set.}
 }
 \value{
 Character string with path to the rendered file or, if


### PR DESCRIPTION
@arnfinn, 
Har lagt til endringer for å løse issue https://github.com/Rapporteket/rapbase/issues/488.

Gjør det mulig å bruke pandoc default latex-mal, og å få ut feilmeldinger fra `rmarkdown::render`.
